### PR TITLE
Milestone 0.2.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,20 @@
+## <small>0.2.7 (2019-11-25)</small>
+
+* perf: do not parse all map string if a key match ([f149f2b](https://github.com/Scrum/postcss-map-get/commit/f149f2b))
+* feat: throw an error if key is not defined ([d74b0a5](https://github.com/Scrum/postcss-map-get/commit/d74b0a5))
+* fix: add error for not closed parenthesis in parse-parenthesis-content ([c75b461](https://github.com/Scrum/postcss-map-get/commit/c75b461))
+* fix: correct some typo in test ([6766729](https://github.com/Scrum/postcss-map-get/commit/6766729))
+
+
+
 ## <small>0.2.6 (2019-11-18)</small>
 
+* 0.2.6 ([f7bef29](https://github.com/Scrum/postcss-map-get/commit/f7bef29))
+* build: update changelog ([8dc7825](https://github.com/Scrum/postcss-map-get/commit/8dc7825))
+* build: update depDev ([50adaef](https://github.com/Scrum/postcss-map-get/commit/50adaef))
 * feat: support nested and multiple invocation ([bac0c27](https://github.com/Scrum/postcss-map-get/commit/bac0c27)), closes [#13](https://github.com/Scrum/postcss-map-get/issues/13)
 * perf: remove babel-plugin-add-module-exports ([bb225c5](https://github.com/Scrum/postcss-map-get/commit/bb225c5))
 * test: multi getters property for issue #13 ([0cc4f9c](https://github.com/Scrum/postcss-map-get/commit/0cc4f9c)), closes [#13](https://github.com/Scrum/postcss-map-get/issues/13)
-* build: update depDev ([50adaef](https://github.com/Scrum/postcss-map-get/commit/50adaef))
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-map-get",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-map-get",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "PostCSS plugin for sass-like Map Function",
   "license": "MIT",
   "repository": "Scrum/postcss-map-get",

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,1 +1,3 @@
 export const METHOD = 'map-get((';
+
+export const ERROR_PREFIX = 'postcss – map-get';

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,3 +1,3 @@
 export const METHOD = 'map-get((';
 
-export const ERROR_PREFIX = 'postcss – map-get';
+export const ERROR_PREFIX = 'postcss – map-get –';

--- a/src/parse-parenthesis-content.js
+++ b/src/parse-parenthesis-content.js
@@ -33,7 +33,7 @@ export default function parseParenthesisContent(stringToParse, startingPosition 
    * String should be already validated by postcss but to avoid unclear stacktrace I'll manage the error anyway.
    */
   if (stack.length !== 0) {
-    throw new Error(`${ERROR_PREFIX} – parenthesis not closed`);
+    throw new Error(`${ERROR_PREFIX} parenthesis not closed`);
   }
 
   return {content, position};

--- a/src/parse-parenthesis-content.js
+++ b/src/parse-parenthesis-content.js
@@ -1,7 +1,9 @@
+import {ERROR_PREFIX} from './constant';
+
 /**
  * Get all the content inside brackets
- * @param {string} stringToParse string with parenthesis. This string must start with an `()`
- * @param {string} [startingPosition] to start parsing
+ * @param {string} stringToParse string with parenthesis. This string must start with an `(`
+ * @param {number} [startingPosition] to start parsing
  * @returns {{content: string, position: number}} All the content inside parenthesis including nested properties
  *
  * @todo might worth to parse the string until a `(` is found?
@@ -11,10 +13,10 @@ export default function parseParenthesisContent(stringToParse, startingPosition 
   let content = '';
 
   const stack = [];
-  while (true) { // eslint-disable-line no-constant-condition
+  while (position !== stringToParse.length) {
     const mapChracter = stringToParse[position];
     if (mapChracter === '(') {
-      stack.push(mapChracter);
+      stack.push(position);
     } else if (mapChracter === ')') {
       stack.pop();
     }
@@ -25,6 +27,13 @@ export default function parseParenthesisContent(stringToParse, startingPosition 
     if (stack.length === 0) {
       break;
     }
+  }
+
+  /**
+   * String should be already validated by postcss but to avoid unclear stacktrace I'll manage the error anyway.
+   */
+  if (stack.length !== 0) {
+    throw new Error(`${ERROR_PREFIX} – parenthesis not closed`);
   }
 
   return {content, position};

--- a/src/process-value.js
+++ b/src/process-value.js
@@ -1,4 +1,4 @@
-import {METHOD} from './constant';
+import {METHOD, ERROR_PREFIX} from './constant';
 
 import parseParenthesisContent from './parse-parenthesis-content';
 
@@ -58,6 +58,10 @@ function getKeyFromMapString(mapString, keyParameter) {
         value += currentCharacter;
       }
     }
+  }
+
+  if (!map[keyValue]) {
+    throw new Error(`${ERROR_PREFIX} – unable to find “${keyValue}“ key inside map “(${mapString})“`);
   }
 
   return map[keyValue];

--- a/test/test.parse-parenthesis-content.js
+++ b/test/test.parse-parenthesis-content.js
@@ -31,3 +31,14 @@ tests.forEach(({stringToParse, startPosition, expectedContent}, testIndex) => {
     t.deepEqual(output.position, expectedPosition);
   });
 });
+
+test('it should throw an error when number of parenthesis is not exact', t => {
+  // missing parenthesis position:                     ↓
+  const value = '(map-get((corporate: (textColor: green, ea: (textColor: black), corporate), textColor)';
+
+  const testError = t.throws(() => {
+    parseParenthesisContent(value);
+  }, null);
+
+  t.is(testError.message, 'postcss – map-get – parenthesis not closed');
+});

--- a/test/test.plugin.js
+++ b/test/test.plugin.js
@@ -12,7 +12,7 @@ test('it should return body color for background', t => {
   t.is(processing(value), expected);
 });
 
-test('it should return body color and min-width width fro decl', t => {
+test('it should return body color and min-width width from decl', t => {
   const expected = 'body{background: #fff;min-width: 1280px;}';
   const value = 'body{background: map-get((body: #fff,main-red: #c53831,link-blue: #0592fb) !default, body);min-width: map-get((xxs: 0,xs: 576px,sm: 768px,md: 992px,lg: 1280px,xl: 1360px,xxl: 1600px) !default, lg);}';
   t.is(processing(value), expected);
@@ -36,7 +36,7 @@ test('it should keep proper string format for element before invocation, borderC
   t.is(processing(value), expected);
 });
 
-test('it should keep proper string format for element before invocation, borderStyle', t => {
+test('it should keep proper string format for element before and after invocation, borderStyle', t => {
   const expected = '.foo {border: 1px solid #FFF;}';
   const value = '.foo {border: 1px map-get((borderStyle: solid) !default, borderStyle) #FFF;}';
   t.is(processing(value), expected);

--- a/test/test.plugin.js
+++ b/test/test.plugin.js
@@ -53,3 +53,15 @@ test('it should resolve nested invocation', t => {
   const value = '.foo {color: map-get(map-get((corporate: (textColor: green), ea: (textColor: black)), corporate), textColor)}';
   t.is(processing(value), expected);
 });
+
+test('it should throw an error when key is not defined', t => {
+  const requestedKey = 'notfound';
+  const map = '(main: #FF0000)';
+  const value = `.foo { color: map-get(${map}, ${requestedKey}) }`;
+
+  const testError = t.throws(() => {
+    processing(value);
+  }, null);
+
+  t.is(testError.message, `postcss – map-get – unable to find “${requestedKey}“ key inside map “${map}“`);
+});


### PR DESCRIPTION
I've added some "integrity" features to the plugin:

- Check on opening / closing of parenthesis.
- Throw an error if requested key is not present in the map
- If requested key is found in the string do not parse the rest of the string

