### PR TITLE
fix: remove whitespace and line breaks from map keys

### DIFF
--- a/src/process-value.js
+++ b/src/process-value.js
@@ -12,6 +12,8 @@ function getKeyFromMapString(mapString, keyParameter) {
   const keyValue = keyParameter.replace(/\s/g, '');
   // remove open and close parenthesis from the map string
   mapString = mapString.slice(1, -1);
+  // remove all line breaks from the map string
+  mapString = mapString.replace(/(\r\n|\n|\r)/gm, '');
 
   let isParsingKey = true;
   let hasFinishedParsingValue = false;
@@ -55,6 +57,8 @@ function getKeyFromMapString(mapString, keyParameter) {
     }
 
     if (hasFinishedParsingValue) {
+      // remove whitespace from parsed key
+      key = key.replace(/\s/g, '');
       if (key === keyValue) {
         return value.trim();
       }

--- a/test/test.plugin.js
+++ b/test/test.plugin.js
@@ -65,3 +65,9 @@ test('it should throw an error when key is not defined', t => {
 
   t.is(testError.message, `postcss – map-get – unable to find “${requestedKey}“ key inside map “${map}“`);
 });
+
+test('it should remove line breaks and space from map key only', t => {
+  const expected = '.foo {border: 1px solid black}';
+  const value = '.foo {border: map-get((\n  border: 1px solid black), border)}';
+  t.is(processing(value), expected);
+});


### PR DESCRIPTION
I've come across an issue using this package with the latest version of postcss-cli (6.1.3) where map keys can not be found due to line breaks and whitespace being present within the map.
